### PR TITLE
Update zetta-device dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/zettajs/zetta-http-device",
   "dependencies": {
-    "zetta-device": "^0.19.0"
+    "zetta-device": "^0.22.0"
   }
 }


### PR DESCRIPTION
Updating zetta-device to prevent the "Deprecation Warning: Device driver using old version of zetta-device upgrade to >= v0.19.0" message.